### PR TITLE
mute/unmute audio without activating tab

### DIFF
--- a/js/components/tab.js
+++ b/js/components/tab.js
@@ -76,7 +76,8 @@ class Tab extends ImmutableComponent {
     windowActions.closeFrame(this.props.frames, this.props.frameProps)
   }
 
-  onMuteFrame (muted) {
+  onMuteFrame (muted, event) {
+    event.stopPropagation()
     windowActions.setAudioMuted(this.props.frameProps, muted)
   }
 


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

fix #2406